### PR TITLE
Expose Iterator type aliases and necessary updates for Go 1.23

### DIFF
--- a/btree.go
+++ b/btree.go
@@ -59,3 +59,7 @@ func (t *Set[K]) Delete(item K) (removed bool) {
 	_, _, removed = t.Map.Delete(item)
 	return removed
 }
+
+type MapIterator[K, V any] = abstract.Iterator[K, V, struct{}]
+
+type SetIterator[T any] = MapIterator[T, struct{}]

--- a/btree.go
+++ b/btree.go
@@ -14,7 +14,7 @@
 
 package btree
 
-import "github.com/ajwerner/btree/internal/abstract"
+import "github.com/anacrolix/btree/internal/abstract"
 
 // Map is a ordered map from K to V.
 type Map[K, V any] struct {

--- a/btree_example_test.go
+++ b/btree_example_test.go
@@ -18,7 +18,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/ajwerner/btree"
+	"github.com/anacrolix/btree"
 )
 
 func ExampleMap() {

--- a/btree_test.go
+++ b/btree_test.go
@@ -17,7 +17,7 @@ package btree
 import (
 	"testing"
 
-	"github.com/ajwerner/btree/internal/ordered"
+	"github.com/anacrolix/btree/internal/ordered"
 )
 
 func TestBTree(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/ajwerner/btree
+module github.com/anacrolix/btree
 
 go 1.23
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ajwerner/btree
 
-go 1.18
+go 1.23
 
 require github.com/stretchr/testify v1.6.1
 

--- a/internal/abstract/iterator.go
+++ b/internal/abstract/iterator.go
@@ -62,7 +62,7 @@ func (i *Iterator[K, V, A]) SeekGE(key K) {
 	}
 }
 
-// SeekLT seeks to the first key less-than the provided key.
+// SeekLT seeks to the last key less-than the provided key.
 func (i *Iterator[K, V, A]) SeekLT(key K) {
 	i.Reset()
 	if i.node == nil {
@@ -167,7 +167,7 @@ func (i *Iterator[K, V, A]) Valid() bool {
 }
 
 // Cur returns the key at the Iterator's current position. It is illegal
-// to call Key if the Iterator is not valid.
+// to call Cur if the Iterator is not valid.
 func (i *Iterator[K, V, A]) Cur() K {
 	return i.node.keys[i.pos]
 }

--- a/internal/ordered/compare.go
+++ b/internal/ordered/compare.go
@@ -16,10 +16,12 @@
 // constraints.Ordered.
 package ordered
 
-import "constraints"
+import (
+	"cmp"
+)
 
 // Compare is a comparison function for ordered types.
-func Compare[T constraints.Ordered](a, b T) int {
+func Compare[T cmp.Ordered](a, b T) int {
 	switch {
 	case a < b:
 		return -1

--- a/interval/aug.go
+++ b/interval/aug.go
@@ -15,7 +15,7 @@
 
 package interval
 
-import "github.com/ajwerner/btree/internal/abstract"
+import "github.com/anacrolix/btree/internal/abstract"
 
 type aug[K any] struct {
 	keyBound[K]

--- a/interval/example_test.go
+++ b/interval/example_test.go
@@ -18,8 +18,8 @@ import (
 	"cmp"
 	"fmt"
 
-	"github.com/ajwerner/btree/internal/ordered"
-	"github.com/ajwerner/btree/interval"
+	"github.com/anacrolix/btree/internal/ordered"
+	"github.com/anacrolix/btree/interval"
 )
 
 type pair[T cmp.Ordered] [2]T

--- a/interval/example_test.go
+++ b/interval/example_test.go
@@ -15,14 +15,14 @@
 package interval_test
 
 import (
-	"constraints"
+	"cmp"
 	"fmt"
 
 	"github.com/ajwerner/btree/internal/ordered"
 	"github.com/ajwerner/btree/interval"
 )
 
-type pair[T constraints.Ordered] [2]T
+type pair[T cmp.Ordered] [2]T
 
 func (p pair[T]) compare(o pair[T]) int {
 	if c := ordered.Compare(p.first(), o.first()); c != 0 {
@@ -34,7 +34,7 @@ func (p pair[T]) compare(o pair[T]) int {
 func (p pair[T]) first() T  { return p[0] }
 func (p pair[T]) second() T { return p[1] }
 
-func ExampleBlog() {
+func Example() {
 	m := interval.MakeSet(
 		ordered.Compare[int],
 		pair[int].compare,

--- a/interval/interval.go
+++ b/interval/interval.go
@@ -14,7 +14,7 @@
 
 package interval
 
-import "github.com/ajwerner/btree/internal/abstract"
+import "github.com/anacrolix/btree/internal/abstract"
 
 // Map is a ordered map from I to V where I is an interval. Its iterator
 // provides efficient overlap queries.

--- a/interval/interval_span_test.go
+++ b/interval/interval_span_test.go
@@ -24,8 +24,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ajwerner/btree/internal/abstract"
-	"github.com/ajwerner/btree/internal/ordered"
+	"github.com/anacrolix/btree/internal/abstract"
+	"github.com/anacrolix/btree/internal/ordered"
 	"github.com/stretchr/testify/require"
 )
 

--- a/interval/interval_test.go
+++ b/interval/interval_test.go
@@ -17,7 +17,7 @@ package interval
 import (
 	"testing"
 
-	"github.com/ajwerner/btree/internal/ordered"
+	"github.com/anacrolix/btree/internal/ordered"
 	"github.com/stretchr/testify/require"
 )
 

--- a/interval/iterator.go
+++ b/interval/iterator.go
@@ -18,7 +18,7 @@ package interval
 import (
 	"sort"
 
-	"github.com/ajwerner/btree/internal/abstract"
+	"github.com/anacrolix/btree/internal/abstract"
 )
 
 type Iterator[I, K, V any] struct {

--- a/orderstat/order_stat.go
+++ b/orderstat/order_stat.go
@@ -17,7 +17,7 @@ package orderstat
 import (
 	"fmt"
 
-	"github.com/ajwerner/btree/internal/abstract"
+	"github.com/anacrolix/btree/internal/abstract"
 )
 
 // Map is a ordered map from K to V which additionally offers the methods

--- a/orderstat/order_stat_test.go
+++ b/orderstat/order_stat_test.go
@@ -19,7 +19,7 @@ import (
 	"math/rand"
 	"testing"
 
-	"github.com/ajwerner/btree/internal/ordered"
+	"github.com/anacrolix/btree/internal/ordered"
 	"github.com/stretchr/testify/require"
 )
 

--- a/orderstat/order_stat_test.go
+++ b/orderstat/order_stat_test.go
@@ -88,7 +88,7 @@ func TestOrderStatNth(t *testing.T) {
 
 }
 
-func ExampleBlog() {
+func Example() {
 	s := MakeSet(ordered.Compare[int])
 	for _, i := range rand.Perm(100) {
 		s.Upsert(i)


### PR DESCRIPTION
Not sure if you're still maintaining this module, but I use it very heavily in several projects.